### PR TITLE
Smaal fixes. Set ref link state of gift links to SentToLykkeSharedWal…

### DIFF
--- a/client/Lykke.blue.Service.ReferralLinks.Client/Models/ClaimReferralLinkDto.cs
+++ b/client/Lykke.blue.Service.ReferralLinks.Client/Models/ClaimReferralLinkDto.cs
@@ -13,7 +13,7 @@ namespace Lykke.blue.Service.ReferralLinks.Client.Models
             return new ClaimReferralLinkDto
             {
                 TransactionRewardRecipient = model.TransactionRewardRecipient,
-                TransactionRewardSender = model.TransactionRewardRecipient,
+                TransactionRewardSender = model.TransactionRewardSender,
                 SenderTransactionId = model.SenderTransactionId
             };
         }

--- a/src/Lykke.blue.Service.ReferralLinks/Controllers/ReferralLinksController.cs
+++ b/src/Lykke.blue.Service.ReferralLinks/Controllers/ReferralLinksController.cs
@@ -198,6 +198,15 @@ namespace Lykke.blue.Service.ReferralLinks.Controllers
 
                 if (groupTransferResult.IsOk())
                 {
+                    foreach (var refLink in refLinkGroup)
+                    {
+                        refLink.SenderTransactionId = groupTransferResult.TransactionId;
+                        refLink.State = ReferralLinkState.SentToLykkeSharedWallet.ToString();
+                        await _referralLinksService.UpdateAsync(refLink);
+                    }
+
+                    await LogInfo(request, ControllerContext, $"{refLinkGroup.Count} gift coin ref link(s) have been created. Total reward amount is {refLinkGroup.Sum(r => r.Amount)} from the specified asset. Transferred to Lykke shared wallet with SenderTransactionId {groupTransferResult.TransactionId} ");
+
                     return Created($"api/referralLinks/giftCoins/sender/{request.SenderClientId}", "");
                 }
 

--- a/src/Lykke.blue.Service.ReferralLinks/Modules/ServiceModule.cs
+++ b/src/Lykke.blue.Service.ReferralLinks/Modules/ServiceModule.cs
@@ -110,7 +110,7 @@ namespace Lykke.blue.Service.ReferralLinks.Modules
                 var ctx = c.Resolve<IComponentContext>();
                 return new CachedDataDictionary<string, Lykke.Service.Assets.Client.Models.Asset>(
                     async () =>
-                        (await ctx.Resolve<IAssetsService>().AssetGetAllWithHttpMessagesAsync()).Body.ToDictionary(itm => itm.Id));   
+                        (await ctx.Resolve<IAssetsService>().AssetGetAllWithHttpMessagesAsync(true)).Body.ToDictionary(itm => itm.Id));   
             }).SingleInstance();
 
             builder.Register(x =>


### PR DESCRIPTION
Small fixes. Set ref link state of gift links to SentToLykkeSharedWallet and the SenderTransactionId when generating group of links. Include NonTradable assets (set flag to true) when retriving assests from service