### PR TITLE
Gift coin link state must be SentToLykkeSharedWallet to be considered…

### DIFF
--- a/src/Lykke.blue.Service.ReferralLinks.AzureRepositories/ReferralLink/ReferralLinkRepository.cs
+++ b/src/Lykke.blue.Service.ReferralLinks.AzureRepositories/ReferralLink/ReferralLinkRepository.cs
@@ -80,7 +80,7 @@ namespace Lykke.blue.Service.ReferralLinks.AzureRepositories.ReferralLink
         {
             return await _referralLinkTable.GetDataAsync(
                 GetPartitionKey(), 
-                x => x.Type == ReferralLinkType.GiftCoins.ToString() && x.ExpirationDate < DateTime.UtcNow && x.State == ReferralLinkState.Created.ToString()
+                x => x.Type == ReferralLinkType.GiftCoins.ToString() && x.ExpirationDate < DateTime.UtcNow && x.State == ReferralLinkState.SentToLykkeSharedWallet.ToString()
                 );           
         }
 


### PR DESCRIPTION
Gift coin link state must be SentToLykkeSharedWallet to be considered as Expired